### PR TITLE
chore(sigs): add sig calendar

### DIFF
--- a/sig-index.md
+++ b/sig-index.md
@@ -11,3 +11,17 @@ Don't see a SIG here that fits what you're looking for? [Submit a Proposal](sig-
 * [Spinnaker-as-Code](sig-spinnaker-as-code/README.md)
 * [Summit](sig-summit/README.md)
 * [UI / UX](sig-ui-ux/README.md)
+
+# SIG Meeting Calendar
+
+To view the calendar, [click here](https://calendar.google.com/calendar/b/3/embed?showPrint=0&showCalendars=0&mode=AGENDA&height=500&wkst=1&bgcolor=%23FFFFFF&src=spinnaker.io_tr65rjf5mfij7p6vucprkhulcc%40group.calendar.google.com&color=%2342104A&ctz=America%2FLos_Angeles).
+
+If you use Google Calendar, [click here to subscribe](https://calendar.google.com/calendar/b/3?cid=c3Bpbm5ha2VyLmlvX3RyNjVyamY1bWZpajdwNnZ1Y3Bya2h1bGNjQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20).
+
+If you don't use Google Calendar or have trouble with the first link, you can copy this iCal URL to subscribe using your calendar app of choice (instructions for [Google](https://support.google.com/calendar/answer/37100), [Apple Calendar](https://support.apple.com/guide/calendar/subscribe-to-calendars-icl1022/mac)):
+
+   ```
+   https://calendar.google.com/calendar/ical/spinnaker.io_tr65rjf5mfij7p6vucprkhulcc%40group.calendar.google.com/public/basic.ics
+   ```
+
+

--- a/sig-index.md
+++ b/sig-index.md
@@ -14,7 +14,7 @@ Don't see a SIG here that fits what you're looking for? [Submit a Proposal](sig-
 
 # SIG Meeting Calendar
 
-To view the calendar, [click here](https://calendar.google.com/calendar/b/3/embed?showPrint=0&showCalendars=0&mode=AGENDA&height=500&wkst=1&bgcolor=%23FFFFFF&src=spinnaker.io_tr65rjf5mfij7p6vucprkhulcc%40group.calendar.google.com&color=%2342104A&ctz=America%2FLos_Angeles).
+To view the calendar, [click here](https://calendar.google.com/calendar/b/3/embed?showPrint=0&showCalendars=0&mode=AGENDA&height=500&wkst=1&bgcolor=%23FFFFFF&src=spinnaker.io_tr65rjf5mfij7p6vucprkhulcc%40group.calendar.google.com&color=%2342104A).
 
 If you use Google Calendar, [click here to subscribe](https://calendar.google.com/calendar/b/3?cid=c3Bpbm5ha2VyLmlvX3RyNjVyamY1bWZpajdwNnZ1Y3Bya2h1bGNjQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20).
 


### PR DESCRIPTION
I'm adding the calendar info to the sig-index page since we're using that as the source of truth.

When the governance info was removed from spinnaker.io, the calendar info for SIGs disappeared with it (https://github.com/spinnaker/spinnaker.github.io/pull/1598). 

