### PR TITLE
docs(governance): the community repo was renamed to governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Spinnaker Community
+# Spinnaker Governance
 
-Welcome to the Spinnaker Community! 
+Welcome to the Spinnaker Community!
 
 This is the starting point for joining and contributing to the Spinnaker community.
 A good place to start is by viewing the [Roadmap](roadmap.md).

--- a/governance.md
+++ b/governance.md
@@ -33,9 +33,9 @@ Qualification guidelines
 * Has submitted at least 5 PRs of significant scope that are correspondingly merged
 * Sponsored by 2 Approvers
 
-[Current Reviewers](https://github.com/spinnaker/community/blob/master/membership.yml)
+[Current Reviewers](https://github.com/spinnaker/governance/blob/master/membership.yml)
 
-If you’d like to nominate yourself as a Reviewer, please create an [Issue in the community repository](https://github.com/spinnaker/community/issues). 
+If you’d like to nominate yourself as a Reviewer, please create an [Issue in the governance repository](https://github.com/spinnaker/governance/issues). 
 
 ### Approvers
 

--- a/rfc/java11.md
+++ b/rfc/java11.md
@@ -3,7 +3,7 @@
 | | |
 |-|-|
 | **Status**     | _**Proposed**, Accepted, Implemented, Obsolete_ |
-| **RFC #**      | [62](https://github.com/spinnaker/community/pull/62) |
+| **RFC #**      | [62](https://github.com/spinnaker/governance/pull/62) |
 | **Author(s)**  | Michael Plump ([`@plumpy`](https://github.com/plumpy)) |
 | **SIG / WG**   | Platform SIG |
 

--- a/rfc/plugins.md
+++ b/rfc/plugins.md
@@ -3,7 +3,7 @@
 | | |
 |-|-|
 | **Status** | Proposed, **Accepted**, Implemented, Obsolete |
-| **RFC  Num** | [#43](https://github.com/spinnaker/community/pull/43) |
+| **RFC  Num** | [#43](https://github.com/spinnaker/governance/pull/43) |
 | **Author(s)** | Rob Zienert (`@robzienert`), Cameron Motevasselani (`@link108`) |
 | **SIG / WG** | Platform SIG |
 | **Obsoletes** | [spinnaker/spinnaker#4181](https://github.com/spinnaker/spinnaker/issues/4181) |


### PR DESCRIPTION
I suppose the info from the README should move back to the website now?