### PR TITLE
Add links to a time zone converter.

### DIFF
--- a/sig-aws/README.md
+++ b/sig-aws/README.md
@@ -29,7 +29,7 @@ _Armory_
 
 ### Meeting Cadence
  - 1 hour, monthly, on **[Google Hangouts](https://meet.google.com/yfp-ekod-sxj)**
- - Third Wednesday of every month at 3PM PST
+ - Third Wednesday of every month at 3 PM US/Pacific ([See in your time zone](https://www.thetimezoneconverter.com/?t=3pm&tz=San%20Francisco))
  - [AWS SIG Notes](https://docs.google.com/document/d/1TB7dSQDTM9jFBsttuevxOsP6MGQ3-z0wrYMIGxYxhYQ/edit)
 
 # Responsibilities

--- a/sig-ci/README.md
+++ b/sig-ci/README.md
@@ -8,8 +8,8 @@ This SIG is focused on CI (continuous integration) experience within Spinnaker.
 ## Meetings
 
 * Regular SIG Meeting
-  * Every other Tuesday, 1 PM EST / 10AM PST
-  
+  * Every other Tuesday, 10 AM US/Pacific ([See in your time zone](https://www.thetimezoneconverter.com/?t=10am&tz=San%20Francisco))
+
   [Agenda](https://docs.google.com/document/d/1vV5lzBydtPQVwIADxdb7eKqq5yoBhA4pEJrxksLuXdE/edit?usp=sharing)
 
 ## Leadership

--- a/sig-ci/README.md
+++ b/sig-ci/README.md
@@ -9,7 +9,7 @@ This SIG is focused on CI (continuous integration) experience within Spinnaker.
 
 * Regular SIG Meeting
 
-  * Every other Wednesay, 10 AM US/Pacific ([See in your time zone](https://www.thetimezoneconverter.com/?t=10am&tz=San%20Francisco))
+  * Every other Wednesday, 10 AM US/Pacific ([See in your time zone](https://www.thetimezoneconverter.com/?t=10am&tz=San%20Francisco))
 
   [Agenda](https://docs.google.com/document/d/1vV5lzBydtPQVwIADxdb7eKqq5yoBhA4pEJrxksLuXdE/edit?usp=sharing)
 

--- a/sig-documentation/README.md
+++ b/sig-documentation/README.md
@@ -1,7 +1,7 @@
 # Spinnaker Documentation Special Interest Group
 
 ## Meeting Info
-* First Wednesday of every month at 11:00 AM Pacific/2:00 PM Eastern
+* First Wednesday of every month at 11 AM US/Pacific ([See in your time zone](https://www.thetimezoneconverter.com/?t=11am&tz=San%20Francisco))
 * [Agenda and notes](https://docs.google.com/document/d/1uErNfK3Yr6LKELNSO7YfsRFyJVHqjivfzIO4nBmMCUw/edit)
 * [Meeting link](https://meet.google.com/umg-qugw-mjy)
 

--- a/sig-kubernetes/README.md
+++ b/sig-kubernetes/README.md
@@ -5,7 +5,7 @@ The Kubernetes SIG is responsible for the integration between Spinnaker and Kube
 ## Meetings
 
 * Regular SIG Meeting
-  * Every other Tuesday, 1 PM ET / 10AM PT
+  * Every other Tuesday, 10 AM US/Pacific ([See in your time zone](https://www.thetimezoneconverter.com/?t=10am&tz=San%20Francisco))
   * [Agenda](https://docs.google.com/document/d/1db_yw1uru99Byvin4lQgm7aUZ9xMmvsARtEiiNUrmBo/edit)
   * [Meeting Link](https://meet.google.com/oto-qwpw-dgt)
 

--- a/sig-platform/README.md
+++ b/sig-platform/README.md
@@ -5,7 +5,7 @@ The Platform SIG is tasked with the oversight of internal processes and tooling 
 ## Meetings
 
 * Regular SIG Sync
-  * Every other Thursday, 2PM EST / 11AM PST
+  * Every other Thursday, 11 AM US/Pacific ([See in your time zone](https://www.thetimezoneconverter.com/?t=11am&tz=San%20Francisco))
   * [Agenda](https://docs.google.com/document/d/1zGIgEwO9lZfYaI0N6necuH-x0SjmL3hmbbeMWZgqnEw/edit#heading=h.ilrqo6qoiejr)
   * [Videoconference Link](https://meet.google.com/qtz-ykko-ddp)
 

--- a/sig-security/README.md
+++ b/sig-security/README.md
@@ -5,7 +5,7 @@ _TODO description_
 ## Meetings
 
 * Regular SIG Meeting
-  * Every other Thursday, 2 PM EST / 11 AM PST
+  * Every other Thursday, 11 AM US/Pacific ([See in your time zone](https://www.thetimezoneconverter.com/?t=11am&tz=San%20Francisco))
   * [Agenda](https://docs.google.com/document/d/1GhzhmG7ZytJBfW2lontOSBxVghgNZmxstF49SoocTDQ/edit#heading=h.ilm7rdxf4d42)
 
 ## Leadership

--- a/sig-spinnaker-as-code/README.md
+++ b/sig-spinnaker-as-code/README.md
@@ -5,7 +5,7 @@ _TODO description_
 ## Meetings
 
 * Regular SIG Meeting
-  * Every other Tuesday, 4 PM EST / 1 PM PST
+  * Every other Tuesday, 1 PM US/Pacific ([See in your time zone](https://www.thetimezoneconverter.com/?t=1pm&tz=San%20Francisco))
   * [Agenda](https://docs.google.com/document/d/1qgtwod1WC9pGNLyq7j1pXDLCAhO3Norf3Afx1FP4Jag/edit#heading=h.h9ro0baz3lei)
 
 ## Leadership

--- a/sig-summit/README.md
+++ b/sig-summit/README.md
@@ -5,14 +5,14 @@ This SIG is focused on planning and alignment for the annual Spinnaker Summit co
 ## Meetings
 
 * Regular SIG Meeting
-  * Every other Tuesday, 1 PM EST / 10AM PST
-  
+  * Every other Tuesday, 10 AM US/Pacific ([See in your time zone](https://www.thetimezoneconverter.com/?t=10am&tz=San%20Francisco))
+
   [Agenda](https://docs.google.com/document/d/1Z65IHImNlJbYq3XvVgnWtijhWj3iUlMGG5uQudjhTe4/edit)
 
 ## Leadership
 
 * Michael Galloway ([michaelgalloway](https://github.com/michaelgalloway))
-* Greg Comstock 
+* Greg Comstock
 
 ## Contact
 

--- a/sig-ui-ux/README.md
+++ b/sig-ui-ux/README.md
@@ -5,7 +5,7 @@ _TODO description_
 ## Meetings
 
 * Regular SIG Meeting
-  * Monthly on the first Monday, 2 PM EST / 11 AM PST
+  * Monthly on the first Monday, 11 AM US/Pacific ([See in your time zone](https://www.thetimezoneconverter.com/?t=11am&tz=San%20Francisco))
   * [Agenda](https://docs.google.com/document/d/1E7b-2CXvdh23fyKu2BjJzKg2KK4245hWqy7mDz7IkBQ/edit)
 
 ## Leadership


### PR DESCRIPTION
Someone in New Zealand was confused about what "Pacific" and "Eastern"
meant. I can't put a UTC time because the UTC time changes whenever we
shift to/from DST.

So I settled on US/Pacific, which should be unambiguous (as opposed to
"PST", which is both confusing and also technically only refers to the
winter time zone) and added a link to a time zone converter.