### PR TITLE
feat(rfc): Change halyard rfc to approved and add name

### DIFF
--- a/rfc/halyard-lite.md
+++ b/rfc/halyard-lite.md
@@ -2,7 +2,7 @@
 
 | | |
 |-|-|
-| **Status**     | _**Proposed**, Accepted, Implemented, Obsolete_ |
+| **Status**     | _Proposed, **Accepted**, Implemented, Obsolete_ |
 | **RFC #**      | [89](https://github.com/spinnaker/governance/pull/89) |
 | **Author(s)**  | Eric Zimanyi (@ezimanyi) |
 | **SIG / WG**   | Kubernetes SIG |


### PR DESCRIPTION
* feat(rfc): Change status to approved 

  I guess this became approved at the moment it had TOC signoff and was merged; let's officially update it.

* feat(rfc): Update Halyard Lite rfc to refer to kleat by name 

  Since the RFC has publish, the new tool to replace Halyard has been named 'kleat'. Refer to it by this name in the RFC instead of by 'Halyard Lite'.
