### PR TITLE
feat(rfc): close out RFCS for EOL of Kubernetes V1 provider and legac…

### DIFF
--- a/rfc/eol_kubernetes_v1.md
+++ b/rfc/eol_kubernetes_v1.md
@@ -42,7 +42,7 @@ The Spinnaker Kubernetes SIG and Slack channels operate best with a common found
 
 ## Timeline
 
-Each set of milestones should be complete by the time the corresponding Spinnaker version is released.
+Each set of milestones should be complete by the time the corresponding Spinnaker or Halyard version is released.
 
 | Spinnaker Version | Release Window Opens | Milestones |
 |-------------------|----------------------|------------|
@@ -50,6 +50,12 @@ Each set of milestones should be complete by the time the corresponding Spinnake
 | 1.19              | 2020-03-02           | Publish a post to the Spinnaker Community Blog explaining why we are removing V1 and how to migrate to V2. Add a feature flag that must be enabled before deploying to V1 accounts. Add appropriate warnings to Halyard, Clouddriver, and Deck. Highlight in 1.19 curated changelog that V1 will be removed in 1.21.
 | 1.20              | 2020-04-27           | Complete audit of community docs and blog posts for V1-related content to update. Highlight in 1.20 curated changelog that V1 will be removed in 1.21.
 | 1.21              | 2020-06-22           | Remove V1-only code from all Spinnaker microservices.
+
+| Halyard Version | Supported Spinnaker Versions | Milestones |
+|-----------------|------------------------------|------------|
+| 1.32            | 1.17, 1.18, 1.19             | Add warning for any configured legacy Kubernetes accounts. Default new and unspecified accounts to standard (V2) provider.
+| 1.36            | 1.18, 1.19. 1.20             | Remove legacy Kubernetes distributed installation path. Spinnaker itself must be deployed using a standard (V2) account.
+| TBD             | 1.21, 1.22, 1.23             | Stop exposing `--provider-version` command, as no supported release will include support for the legacy (V1) provider.
 
 ## Design
 
@@ -89,6 +95,7 @@ Each set of milestones should be complete by the time the corresponding Spinnake
   - [x] Remove V1-only code from Orca ([orca/pull/3654](https://github.com/spinnaker/orca/pull/3654)).
   - [x] Remove V1-only code from Clouddriver ([clouddriver/pull/4569](https://github.com/spinnaker/clouddriver/pull/4569), [clouddriver/pull/4572](https://github.com/spinnaker/clouddriver/pull/4572)).
   - [x] Since no providers now support multiple versions, and no community members (to the best of our knowledge) ever implemented their own UI "skins," remove "skins" from Deck ([deck/pull/8263](https://github.com/spinnaker/deck/pull/8263)), Gate ([gate/pull/1186](https://github.com/spinnaker/gate/pull/1186)), Clouddriver ([clouddriver/pull/4576](https://github.com/spinnaker/clouddriver/pull/4576)), and the docs ([spinnaker.github.io/pull/1838](https://github.com/spinnaker/spinnaker.github.io/pull/1838)).
+  - [x] Remove V1 distributed installation path from Halyard ([halyard/pull/1672](https://github.com/spinnaker/halyard/pull/1672)).
   - [x] When Spinnaker 1.23 is released, no supported release will include the V1 provider.
     Since Kubernetes was the only provider to expose multiple versions, it will then be safe to remove `providerVersion` logic from Halyard and Clouddriver.
     Create a self-assigned issue for this final cleanup ([spinnaker/spinnaker/5749](https://github.com/spinnaker/spinnaker/issues/5749)).

--- a/rfc/legacy_artifacts_ui_removal.md
+++ b/rfc/legacy_artifacts_ui_removal.md
@@ -2,7 +2,7 @@
 
 | | |
 |-|-|
-| **Status**     | _Proposed, **Accepted**, Implemented, Obsolete_ |
+| **Status**     | _Proposed, Accepted, **Implemented**, Obsolete_ |
 | **RFC #**      | [111](https://github.com/spinnaker/governance/pull/111) |
 | **Author(s)**  | Maggie Neterval (`@maggieneterval`) |
 | **SIG / WG**   | UI/UX SIG |
@@ -66,13 +66,18 @@ the new UI, but no comprehensive audit of the new UI by Spinnaker maintainers.
 
 ## Timeline
 
-Each set of milestones should be complete by the time the corresponding Spinnaker version is released.
+Each set of milestones should be complete by the time the corresponding Spinnaker or Halyard version is released.
 
 | Spinnaker Version | Release Window Opens | Milestones |
 |-------------------|----------------------|------------|
 | 1.20              | 2020-04-27           | New UI is enabled by default. Legacy UI is behind a feature flag.
 | 1.21              | 2020-06-22           | Legacy UI is removed.
 | 1.23              | TBD                  | Legacy UI documentation is removed.
+
+| Halyard Version | Supported Spinnaker Versions | Milestones |
+|-----------------|------------------------------|------------|
+| 1.35            | 1.17, 1.18. 1.19             | Log warning that `--artifacts` and `--artifacts-rewrite` feature flags are no longer used in Spinnaker >= 1.20.
+| TBD             | 1.20, 1.21, 1.22             | Remove `--artifacts` and `--artifacts-rewrite` feature flags, as no supported release consumes them.
 
 ## Design
 
@@ -110,13 +115,18 @@ updating the artifacts documentation, and adding a section to the 1.20 release
 notes ([halyard/pull/1620](https://github.com/spinnaker/halyard/pull/1620),
 [spinnaker.github.io/pull/1806](https://github.com/spinnaker/spinnaker.github.io/pull/1806)).
 
-- [] For release 1.21, remove the `legacyArtifactsEnabled` flag and all legacy
-UI code. Communicate this change by updating the artifacts documentation and
-adding a section to the 1.21 release notes.
+- [x] For release 1.21, remove the `legacyArtifactsEnabled` flag and all legacy
+UI code ([deck/pull/8273](https://github.com/spinnaker/deck/pull/8273)).
+Communicate this change by adding a section to the 1.21 release notes.
 
-- [] After release 1.23, we can remove the legacy UI documentation and Halyard
-feature flags because no supported release (1.21, 1.22, 1.23) will include
-legacy UI support.
+- [x] After release 1.23, we can remove the legacy UI documentation, as no
+supported release (1.21, 1.22, 1.23) will include the legacy UI. Create a
+self-assigned issue to track this ([spinnaker/spinnaker/5756](https://github.com/spinnaker/spinnaker/issues/5756)).
+ 
+- [x] After release 1.22, we can remove Halyard's `--artifacts` and
+`--artifacts-rewrite` feature flags because no supported release (1.20, 1.21,
+1.22) will read from these flags. Create a self-assigned issue to track this
+([spinnaker/spinnaker/5757](https://github.com/spinnaker/spinnaker/issues/5756)).
 
 ## Prior Art and Alternatives
 


### PR DESCRIPTION
…y artifacts UI

I've assigned issues to myself to track the long tail of cleanup work related to these RFCs, but barring any unforeseen issues, we can now mark them implemented. I've also added a Halyard-specific table to the timeline section of each RFC to clarify the timing of each Halyard milestone by Halyard release rather than Spinnaker release.