### PR TITLE
feat(sig-as-code): add luispollo as lead, remove emjburns

### DIFF
--- a/sig-spinnaker-as-code/README.md
+++ b/sig-spinnaker-as-code/README.md
@@ -10,7 +10,7 @@ _TODO description_
 
 ## Leadership
 
-* Emily Burns ([emjburns](https://github.com/emjburns))
+* Luis Pollo ([luispollo](https://github.com/luispollo)
 * Rob Fletcher ([robfletcher](https://github.com/robfletcher))
 
 ## Contact


### PR DESCRIPTION
Stepping down as SIG lead, and nominating @luispollo to replace me.

@spinnaker/sc PTAL