### PR TITLE
Add Daniel West as reviewer

### DIFF
--- a/membership.yml
+++ b/membership.yml
@@ -26,6 +26,7 @@ organization:
       members:
       - amanya
       - andrewbackes
+      - dwest-netflix
       - dotdotdotpaul
       - flyinprogrammer
       - german-muzquiz


### PR DESCRIPTION
Daniel West (@dwest-netflix) has made contributions to the [Kayenta](https://github.com/spinnaker/kayenta/commits?author=dwest-netflix) and [Orca](https://github.com/spinnaker/orca/commits?author=dwest-netflix) codebases. Although he has only made four PRs (the criteria for approvers is five), there is an expectation that he will be one of the core Netflix contributors to Kayenta, and it would be great if we could make an exception here.

Both @csanden and I sponsor him.