### PR TITLE
Proposal for Azure SIG

### DIFF
--- a/sig-azure/README.md
+++ b/sig-azure/README.md
@@ -9,7 +9,7 @@ Architect Software Engineer \
 _Salesforce_
 
 **[Harikumar Kumar Sulochana](https://github.com/harikumarks)** \
-Senior Software Engineer \
+Principal Software Engineer \
 _Salesforce_
 
 

--- a/sig-azure/README.md
+++ b/sig-azure/README.md
@@ -1,0 +1,48 @@
+# Proposal: Spinnaker Azure Special Interest Group
+
+## Roles & Responsibilities of the SIG Leads
+
+### SIG Lead(s):
+
+**[Edgar Magana](https://github.com/emagana)** \
+Architect Software Engineer \
+_Salesforce_
+
+**[Harikumar Kumar Sulochana](https://github.com/harikumarks)** \
+Senior Software Engineer \
+_Salesforce_
+
+
+### SIG Lead Responsibility
+
+1. Coordinate communication.
+2. Set meeting dates and objectives for the coming year.
+3. Curate agenda for each meeting.
+4. Raise awareness and invite appropriate participants.
+5. Encourage and foster an inclusive environment.
+6. Facilitate the identification and development of resources (people or funding) for support of Microsoft Azure Cloud within Spinnaker.
+
+
+### Meeting Cadence
+ - 1 hour, monthly, on **[Google Hangouts](https://meet.google.com/mmy-bkuo-wrk)**
+ - Second Tuesday of every month at 8:00 AM US/Pacific ([See in your time zone](https://www.thetimezoneconverter.com/?t=8:00am&tz=San%20Francisco))
+ - [Azure SIG Notes](https://docs.google.com/document/d/1NNG-tbckMoiIjxETMdoPikxBjS8AU1oRNbA7piSogpY/edit?usp=sharing)
+
+# Responsibilities
+
+## Description
+
+Azure SIG is responsible for the creation and maintenance of subprojects & subservices necessary to integrate Microsoft Azure Cloud services with Spinnaker.
+
+Azure SIG also acts as a forum for discussions and feature demos for Spinnaker users on Microsoft Azure Cloud. SIG leads in collaboration with SIG members will develop, maintain and prioritize a backlog of features. This prioritization will be published as the Azure SIG Roadmap.
+
+
+## Scope of Work
+
+TBC
+
+## Contact
+
+* [Slack](http://spinnakerteam.slack.com/messages/sig-azure)
+* [Mailing List](https://groups.google.com/a/spinnaker.io/forum/#!forum/sig-azure)
+* [Community Issues/PRs](https://github.com/spinnaker/spinnaker/labels/sig%2Fazure)


### PR DESCRIPTION
This commit proposes the creation of the Azure SIG. Salesforce is interested in leading this effort,
we are hoping that other developers and operators from the community join this group.