### PR TITLE
chore(k8s-sig): SIG lead change for Kubernetes SIG

### DIFF
--- a/sig-kubernetes/README.md
+++ b/sig-kubernetes/README.md
@@ -11,7 +11,7 @@ The Kubernetes SIG is responsible for the integration between Spinnaker and Kube
 
 ## Leadership
 
-* Ethan Rogers ([ethanfrogers](https://github.com/ethanfrogers))
+* German Muzquiz ([german-muzquiz](https://github.com/german-muzquiz))
 * Eric Zimanyi ([ezimanyi](https://github.com/ezimanyi))
 
 ## Contact


### PR DESCRIPTION
I'd like to propose @german-muzquiz take over my role as Kubernetes SIG lead. German has been critical in Armory's contribution to the Kubernetes provider and has worked with countless users to help make them successful. I have no doubt that he'll do a fantastic job leading in my place