### PR TITLE
feat(docs): Process for donating community plugins

### DIFF
--- a/.github/ISSUE_TEMPLATE/plugin-ownership-transfer.md
+++ b/.github/ISSUE_TEMPLATE/plugin-ownership-transfer.md
@@ -1,0 +1,27 @@
+---
+name: Plugin Ownership Transfer
+about: Propose a plugin ownership transfer to the [spinnaker-plugins](https://github.com/spinnaker-plugins) organization. For more information, please see the documentation for [community donated plugins](https://github.com/spinnaker/governance/blob/master/sig-platform/community-donated-plugins.md).
+title: 'Plugin Transfer: <plugin name>'
+labels: committee/technical-oversight
+assignees: spinnaker/toc
+
+---
+
+### Plugin Information
+
+Name of the plugin.
+
+Description of what the plugin is.
+
+### Acknowledgements
+
+- [ ] Source code will be available publicly on [`spinnaker-plugins`](https://github.com/spinnaker-plugins)
+- [ ] Donated code must explicitly declare a license
+- [ ] All authors listed below will be given `maintain` permissions to the plugin repository
+- [ ] Plugin authors are expected to continue as primary maintainers of plugin
+- [ ] Spinnaker core contributors are not expected to help maintain the plugin
+- [ ] Spinnaker core contributors will not automatically inherit permissions for plugin repository, with the exception of the Technical Oversight Committee for administrative purposes
+
+### Maintainers
+
+- (at)github_user

--- a/sig-platform/community-donated-plugins.md
+++ b/sig-platform/community-donated-plugins.md
@@ -1,0 +1,14 @@
+# Community Donated Plugins
+
+The [`spinnaker-plugins`](https://github.com/spinnaker-plugins) GitHub organization is a holding organization for unofficial, community-contributed Spinnaker plugins.
+Typical cases for moving a plugin to this organization would include companies who require CLAs for contributions to their main GitHub organizations, but do not want to include that overhead for contributorship to the plugin itself. 
+**Donating a plugin to the `spinnaker-plugins` organization is never required.**
+
+Plugin authors looking to transfer ownership of their plugins to the `spinnaker-plugins` organization will:
+
+- Continue to be the maintainers of their plugin.
+- Will be granted `maintain` access to the repository. Changes to who has access is handled by the TOC and must be done by creating an issue in the [governance](https://github.com/spinnaker/governance) repo by an existing plugin author.
+
+To start the process of transferring a plugin to `spinnaker-plugins`, [create an issue](https://github.com/spinnaker/governance/issues/new/choose) in the governance repository.
+
+Once approved, a member of the Technical Oversight Committee will be in contact for arranging transfer and setup of the repository.


### PR DESCRIPTION
AWS & Autodesk have a number of plugins that they've been collaboratively developing and want to see community involvement with, however, they feel their company CLAs will be a hinderance to contributorship. The idea here is that the [`spinnaker-plugins`](https://github.com/spinnaker-plugins) organization can be used as a home for these plugins. Plugin authors will continue to own the maintenance and day-to-day operations of the repository via `write` access, however the TOC will have access to the org to help with membership as needed.

Question: Should plugin authors be given `write` or `admin` access for their plugin repository? 
