### PR TITLE
Contributor Experience Special Interest Group Charter

### DIFF
--- a/cx-sig-charter-draft.md
+++ b/cx-sig-charter-draft.md
@@ -1,0 +1,142 @@
+# Contributor Experience Special Interest Group Charter
+
+This charter adheres to the conventions described in the [Kubernetes Charter README] and uses the Roles and Organization Management outlined in [sig-governance].
+
+## Scope
+
+The [Contributor Experience Special Interest Group] (SIG) is responsible for improving the experience of those who upstream contribute to the Kubernetes project. We do this by creating, and maintaining programs and processes that promote community health and reduce project friction, while retiring those programs and processes that don't. Being conscientious of our contributor base is critical to scaling the project, growing the ecosystem, and helping the project succeed.
+
+We do this by listening - whether it’s through our roadshows to SIG meetings, surveys, data, or [GitHub issues], we take in the feedback and turn it into our [project list]. We build a welcoming and inclusive community of contributors by giving them places to be heard and productive.
+
+### In scope
+
+#### Code, Binaries and Services
+
+- Establish policies, standards and procedures for the use, [moderation], and management of all public platforms officially used by the project, including but not limited to:
+  - [discuss.kubernetes.io]
+  - [GitHub Management]
+  - [Mailing lists] / Google groups for the project as a whole (eg: kubernetes-dev@googlegroups.com) and for individual sigs and wgs where the Chairs have provided us ownership
+  - [Slack]
+  - [/kubernetescommunity] YouTube channel
+  - [Zoom]
+- Establish and staff teams responsible for the administration and moderation of these platforms
+  - Teams must be staffed by trusted contributors spanning time zones, see [moderation] for more detail
+  - They are authorized to take immediate action when dealing with code of conduct issues, see [moderators] for the full list
+  - They are expected to escalate to the project's code of conduct committee when issues rise above the level of simple moderation
+- Work with other SIGs and interested parties in the project to execute GitHub tasks where required, see [GitHub Management] for more detail
+- Own and execute events that are targeted to the Kubernetes contributor community, including:
+  - The weekly [Kubernetes Community meeting]
+  - [Contributor Summit(s)]
+  - [Steering Committee elections] (though we do not own policy creation, see 'out of scope' below)
+  - Retrospective moderation for other SIGs upon request
+  - Other events, like other SIG face to face events, upon request and consideration
+- Strategize, build, and execute on scalable [mentoring programs] for all contributor levels. These may include:
+  - [Google Summer of Code]
+  - [Outreachy]
+  - [Meet Our Contributors]
+  - [Group Mentoring - WIP]
+  - [The 1:1 Hour - WIP]
+  - Speed Mentoring sessions at selected KubeCon/CloundNativeCon's
+- Help onboard new and current contributors into the culture, workflow, and CI of our contributor experience through the [contributor guide], other related documentation, [contributor summits] and programs tailored to onboarding.
+- Perform issue triage on and maintain the [kubernetes/community] repository.  
+- Help SIGs with being as transparent and open as possible through creating best practices, guidelines, and general administration of YouTube, Zoom, and our mailing lists where applicable
+- Assist SIGs/WG Chairs and Technical Leads with organizational management operations as laid out in the [sig-governance] doc
+- Distribute contributor related news on various Kubernetes channels, including Cloud Native Compute Foundation ([CNCF]) for posting blogs, social media, and other platforms as needed.
+- Establish and share metrics to measure project health, community health, and general trends, including:
+  - ongoing work with the CNCF to improve [DevStats]
+  - the contributor experience survey(s)
+  - engagement on project platforms that we manage
+- Research other OSS projects and consult with their leaders about contributor experience topics to make sure we are always delivering value to our contributors
+
+#### Cross-cutting and Externally Facing Processes
+
+We cross-cut all SIGs and WGs to deliver the following processes:
+
+- Deploying Changes:
+  When implementing policy changes we strive to balance responding quickly to the needs of the community and ensuring a disruption-free experience for project contributors. As such, the amount of notice we provide and the amount of consensus we seek is driven by our estimation of risk. We don't measure risk objectively at this time, but estimate it based on these parameters:
+  - Low-risk changes impact a small number (<4) of SIGs, WGs, or repos, do not break existing contributor workflows, and are easy to roll back. When implementing low-risk changes we:
+    - Socialize on kubernetes-sig-contribex@googlegroups.com and our weekly update calls
+    - We will go to each lead, their mailing lists, slack channel, and/or their update meetings and ask for feedback and a [lazy consensus] process. We will follow up with a post to [kubernetes-dev@]googlegroups.com mailing list
+  - High-risk changes impact a large number (>4) of SIGs, WGs, or repos, break existing contributor workflows, and are not easy to roll back. When implementing high-risk changes we:
+    - Socialize on kubernetes-sig-contribex@googlegroups.com and our weekly update calls
+    - Seek [lazy consensus] with a time box of at least 72 business hours with a GitHub issue link (or proposal if not applicable) to the following mailing lists:
+        - [kubernetes-sig-contribex@]googlegroups.com
+        - sig-leads@googlegroups.com
+        - [kubernetes-dev@]googlegroups.com with the GitHub issue link including the subject [NOTICE]: $announcement
+        - We will also announce it at the weekly Kubernetes Community Meeting on Thursdays
+- Depending on how wide of an ecosystem change this is, we may also slack, blog, tweet, and use other channels to get the word out.
+- Our standard time box is 72 business hours; however, there may be situations where we need to act quickly but the time period will always be clear and upfront.
+- Encourage automation to improve productivity for contributors where it makes sense and consult with SIG Testing if automation is covering GitHub workflows.
+
+If we need funding for any reason, we approach [CNCF].
+CNCF in many of the noted cases above, contributes funding to our platforms, processes, and/or programs. They do not play a day-to-day operations role and have bestowed that to our community to run as we see fit. Since they do fund some of our initiatives, this means that they hold owner account privileges on certain platforms like Zoom and Slack. In these cases, such as Slack, there are at least two Contributor Experience [communication] subproject OWNERs listed as admins.
+
+### Out of scope
+
+- Code for the testing and CI infrastructure - that’s SIG Testing
+- [kubernetes/community]  ownership of folders for KEPs and Design Proposals. Members are to follow those folders owners files and SIG leadership for the specific issue/PR in question.
+- User community management. We hold office hours because contributors are a large portion of the volunteers that run that program.
+- The contributor experience for repos not included in the Kubernetes associated repositories list found in the [GitHub Management] subproject README.
+- Steering committee election policy updates and maintenance.
+- We do not create SIGs/WGs but can assist in the various community management needs of their micro communities that would kick off their formation and keep them going.
+- We are not the [code of conduct committee] and therefore do not control incident management reporting or decisions; however, our moderation guidelines allow us to act swiftly if there is a clear violation of terms of either our code of conduct or one of our supported platforms terms of service. If there is an action that the committee needs to take that involves one of these platforms (example: the removal of someone from GitHub), we will carry that out if none of the committee members have access.
+- Communication platforms that are out of our scope for maintenance and support but we may still have some influence:
+    - [r/kubernetes]
+    - [@kubernetesio] twitter account
+    - [kubernetes blog]
+
+## Roles and Organization Management
+
+This sig adheres to the Roles and Organization Management outlined in [sig-governance]
+and opts-in to updates and modifications to [sig-governance].
+
+
+### Additional responsibilities of Chairs
+
+Chairs SHOULD plan at least one face to face Contributor Experience meeting per year
+
+### Additional responsibilities of Tech Leads
+
+Ensuring that technical changes from subprojects follow the process change communication guidelines listed above.
+
+### Deviations from sig-governance
+Six months after this charter is first ratified, it MUST be reviewed and re-approved by the SIG in order to evaluate the assumptions made in its initial drafting.
+
+### Subproject Creation
+Chairs and Technical Leads
+
+[sig-governance]: https://git.k8s.io/community/committee-steering/governance/sig-governance.md
+[Kubernetes Charter README]: https://git.k8s.io/community/committee-steering/governance/README.md
+[lazy consensus]: http://en.osswiki.info/concepts/lazy_consensus
+[Contributor Experience Special Interest Group]: https://groups.google.com/forum/#!forum/kubernetes-sig-contribex
+[kubernetes-dev@]: https://groups.google.com/forum/#!forum/kubernetes-dev
+[@kubernetesio]: https://www.twitter.com/kubernetesio
+[r/kubernetes]: https://kubernetes.reddit.com
+[Google Summer of Code]: https://git.k8s.io/community/mentoring/google-summer-of-code.md
+[Outreachy]: https://git.k8s.io/community/mentoring/outreachy.md
+[Meet Our Contributors]:  https://git.k8s.io/community/mentoring/meet-our-contributors.md
+[Group Mentoring - WIP]:  https://git.k8s.io/community/mentoring/group-mentoring.md
+[The 1:1 Hour - WIP]: https://git.k8s.io/community/mentoring/the1-on-1hour.md
+[kubernetes/community]: https://git.k8s.io/community/
+[Contributor Summit(s)]: https://git.k8s.io/community/events/2018/12-contributor-summit
+[contributor summits]: https://git.k8s.io/community/events/2018/12-contributor-summit
+[DevStats]: https://k8s.cncf.devstats.io
+[kubernetes-sig-contribex@]: https://groups.google.com/forum/#!forum/kubernetes-sig-contribex
+[kubernetes blog]: https://www.kubernetes.io/blog
+[GitHub Management]: https://git.k8s.io/community/github-management
+[communication]: https://git.k8s.io/community/communication
+[CNCF]: https://cncf.io
+[GitHub issues]: https://github.com/kubernetes/community/issues
+[project list]: https://github.com/orgs/kubernetes/projects/1
+[Kubernetes Community meeting]: https://git.k8s.io/community/communication#weekly-meeting
+[mentoring programs]: https://git.k8s.io/community/mentoring
+[Steering Committee elections]: https://git.k8s.io/community/events/elections
+[Slack]: https://git.k8s.io/community/communication/slack-guidelines.md
+[Zoom]: https://git.k8s.io/community/communication/zoom-guidelines.md
+[/kubernetescommunity]: https://www.youtube.com/kubernetescommunity
+[discuss.kubernetes.io]: https://discuss.kubernetes.io
+[contributor guide]: https://git.k8s.io/community/contributor
+[moderation]: https://git.k8s.io/community/communication/moderation.md
+[code of conduct committee]: https://git.k8s.io/community/committee-code-of-conduct
+[Mailing lists]: https://git.k8s.io/community/communication/moderation.md#specific-guidelines
+[moderators]: https://git.k8s.io/community/communication/moderators.md

--- a/cx-sig-charter-draft.md
+++ b/cx-sig-charter-draft.md
@@ -13,7 +13,6 @@ We do this by listening - whether it’s through our roadshows to SIG meetings, 
 #### Code, Binaries and Services
 
 - Establish policies, standards, and procedures for the use, [moderation], and management of all public platforms officially used by the project, including but not limited to:
-  - [discuss.spinnaker.io]
   - [GitHub Management]
   - [Mailing lists] / Google groups for the project as a whole (eg: <need community mailing list>@googlegroups.com) and for individual sigs and working groups where the Chairs have provided us ownership
   - [Slack]
@@ -107,4 +106,3 @@ Six months after this charter is first ratified, it MUST be reviewed and re-appr
 Chairs and Technical Leads
 
 [sig-governance]: 
-

--- a/cx-sig-charter-draft.md
+++ b/cx-sig-charter-draft.md
@@ -83,7 +83,6 @@ CDF in many of the noted cases above contributes funding to our platforms, proce
 ## Roles and Organization Management
 
 This sig adheres to the Roles and Organization Management outlined in Spinnaker's governance policy and will actively suggest updates to those policies as part of our work.
-and opts-in to updates and modifications to [sig-governance].
 
 
 ### Additional responsibilities of Chairs

--- a/cx-sig-charter-draft.md
+++ b/cx-sig-charter-draft.md
@@ -1,41 +1,42 @@
 # Contributor Experience Special Interest Group Charter
 
-This charter adheres to the conventions described in the [Spinnaker Charter README] and uses the Roles and Organization Management outlined in [sig-governance].
+This charter uses the Roles and Organization Management outlined in [sig-governance](https://github.com/spinnaker/governance/blob/master/governance.md).
 
 ## Scope
 
-The [Contributor Experience Special Interest Group] (SIG) is responsible for improving the experience of those who contribute upstream to the Spinnaker project. We do this by creating, and maintaining programs and processes that promote community health and reduce project friction while retiring those programs and processes that don't. Being conscientious of our contributor base is critical to scaling the project, growing the ecosystem, and helping the project succeed.
+The Contributor Experience Special Interest Group (SIG) is responsible for improving the experience of those who contribute upstream to the Spinnaker project. We do this by creating, and maintaining programs and processes that promote community health and reduce project friction while retiring those programs and processes that don't. Being conscientious of our contributor base is critical to scaling the project, growing the ecosystem, and helping the project succeed.
 
-We do this by listening - whether it’s through our roadshows to SIG meetings, surveys, data, or [GitHub issues], we take in the feedback and turn it into our [project list]. We build a welcoming and inclusive community of contributors by giving them places to be heard and productive.
+We do this by listening - whether it’s through our roadshows to SIG meetings, surveys, data, or [GitHub issues](https://github.com/spinnaker/spinnaker/issues), we take in the feedback and turn it into our project list. We build a welcoming and inclusive community of contributors by giving them places to be heard and productive.
 
 ### In scope
 
 #### Projects & Services
 
--  In accordance with the code of conduct, establish policies, standards, and procedures for the use, [moderation], and management of all public platforms officially used by the project, including but not limited to:
-  - [GitHub Management]
-  - [Slack]
-  - [/spinnaker] YouTube channel
-  - [Zoom]
+-  In accordance with the code of conduct, establish policies, standards, and procedures for the use, moderation, and management of all public platforms officially used by the project, including but not limited to:
+  - [GitHub Management](https://github.com/spinnaker)
+  - [Slack](https://join.spinnaker.io/)
+  - [Spinnaker](https://www.youtube.com/channel/UCcxQbw8kT1-FRhFhO2QCetg) YouTube channel
+  - Zoom
+  - Google Meet
 - Set up alerting automation for GitHub events, including new contributors, new issues, and new pull requests.
-- Work with other SIGs and interested parties in the project to execute GitHub tasks where required, see [GitHub Management] for more detail
+- Work with other SIGs and interested parties in the project to execute GitHub tasks where required, see [GitHub Management](https://github.com/spinnaker) for more detail
 - Own and execute events that are targeted to the Spinnaker contributor community, including:
-  - [Contributor Summit(s)]
-  -[Gardening Days and hackathons]
+  - Contributor Summit(s) 
+  - [Gardening Days and hackathons](https://github.com/spinnaker-hackathon/gardening)
   - Retrospective moderation for other SIGs upon request
   - Other events, like other SIG face to face events, upon request and consideration
-- Strategize, build, and execute on scalable [mentoring programs] for all contributor levels. These may include:
-  - [Google Summer of Code]
-  - [Outreachy]
+- Strategize, build, and execute on scalable mentoring programs for all contributor levels. These may include:
+  - [Google Summer of Code](https://summerofcode.withgoogle.com/archive/)
+  - [Outreachy](https://www.outreachy.org/)
 - New mentoring programs: office hours, meet the contributors, 1:1 pairing, group mentoring, etc.
-- Help onboard new and current contributors into the culture, workflow, and CI of our contributor experience through the [contributor guide], other related documentation, [contributor summits], and programs tailored to onboarding.
-- Perform issue triage on and maintain the [spinnaker/contributor-experience] repository.  
+- Help onboard new and current contributors into the culture, workflow, and CI of our contributor experience through the [contributor guide](https://spinnaker.io/community/contributing/), other related documentation, contributor summits, and programs tailored to onboarding.
+- Perform issue triage on and maintain the spinnaker/contributor-experience repository.  
 - Help SIGs with being as transparent and open as possible through creating best practices, guidelines, and general administration of YouTube, Zoom, and our mailing lists where applicable
 - Document and assist SIGs/WG Chairs and Technical Leads with organizational management operations
-- Distribute contributor related news on various Spinnaker channels, including Continous Delivery Foundation ([CDF]) for posting blogs, social media, and other platforms as needed.
+- Distribute contributor related news on various Spinnaker channels, including Continous Delivery Foundation ([CDF](https://cd.foundation)) for posting blogs, social media, and other platforms as needed.
 - Establish and share metrics to measure project health, community health, and general trends, including:
-  - [DevStats]
-  - the CDF contribution gamification app [WIP]
+  - [DevStats](https://spinnaker.devstats.cd.foundation/)
+  - the CDF contribution gamification app [WIP](https://github.com/ExitoLab/spinnaker_gamification_app)
   - contributor experience survey(s)
   - engagement on project platforms
   - pull request and issue engagement and closure times
@@ -49,18 +50,14 @@ We cross-cut all SIGs and working groups to deliver the following processes:
 
 - Deploying Changes:
  This SIG will create change-deployment policies that balance quick response to the needs of the community and a limit on disruptions for project contributors. We will create policies to socialize and elicit feedback on changes via community channels such as Slack, spinnaker.io, Twitter, mailing lists, SIG meetings, delegating to SIG leads, etc. The amount of notice we provide and the amount of consensus we seek is driven by our estimation of risk. We can estimate risk based on these parameters:
- 
+
 - Low-risk changes impact a small number (<3) of SIGs, working groups, or repositories, do not break existing contributor workflows, and are easy to roll back.
 - High-risk changes impact a large number (>3) of SIGs, working groups, or repositories, break existing contributor workflows and are not easy to roll back.
-  - Low-risk changes impact a small number (<4) of SIGs, working groups, or repositories, do not break existing contributor workflows, and are easy to roll back. When implementing low-risk changes we:
-        - <sig lead mailing list>@googlegroups.com
-        - [<need to figure out what the main mailing list is>@]googlegroups.com with the GitHub issue link including the subject [NOTICE]: $announcement
-        - We will also announce it at the weekly Spinnaker Community Meeting on <we will need to decide on a day>
 - Depending on how wide of an ecosystem change this is, we may also slack, blog, tweet, and use other channels to get the word out.
 - Our standard time box is 72 business hours; however, there may be situations where we need to act quickly but the time period will always be clear and upfront.
 - Encourage automation to improve productivity for contributors where it makes sense, and consult with SIG leads on automation workflows.
 
-If we need funding for any reason, we approach [CDF].
+If we need funding for any reason, we approach [CDF](https://cd.foundation).
 CDF may contribute funding to our platforms, processes, and/or programs. They do not play a day-to-day operations role and have bestowed that to our community to run as we see fit. Since they do fund some of our initiatives, this means that they hold owner account privileges on certain platforms like Zoom and Slack. The CX SIG will work to ensure that project maintainers are included as admins.
 
 ### Out of scope
@@ -69,7 +66,7 @@ CDF may contribute funding to our platforms, processes, and/or programs. They do
 - User community management.
 - The contributor experience for repositories not included in the Spinnaker organization
 - We do not create SIGs/working group but can assist in the various community management needs of their micro-communities that would kick off their formation and keep them going.
-- We are not a [code of conduct committee] and therefore do not control incident management reporting or decisions; however, our mission includes acting swiftly if there is a clear violation of either our code of conduct or one of the terms of our supported platform of service.
+- We are not a code of conduct committee and therefore do not control incident management reporting or decisions; however, our mission includes acting swiftly if there is a clear violation of either our code of conduct or one of the terms of our supported platform of service.
 
 ## Roles and Organization Management
 

--- a/cx-sig-charter-draft.md
+++ b/cx-sig-charter-draft.md
@@ -18,7 +18,6 @@ We do this by listening - whether it’s through our roadshows to SIG meetings, 
   - [Slack]
   - [/spinnaker] YouTube channel
   - [Zoom]
-  - Teams must be staffed by trusted contributors spanning time zones, see [moderation] for more detail
   - They are authorized to take immediate action when dealing with code of conduct issues, see [moderators] for the full list
   - They are expected to escalate to the project's code of conduct committee when issues rise above the level of simple moderation
 - Work with other SIGs and interested parties in the project to execute GitHub tasks where required, see [GitHub Management] for more detail

--- a/cx-sig-charter-draft.md
+++ b/cx-sig-charter-draft.md
@@ -36,7 +36,7 @@ We do this by listening - whether it’s through our roadshows to SIG meetings, 
 - Distribute contributor related news on various Spinnaker channels, including Continous Delivery Foundation ([CDF](https://cd.foundation)) for posting blogs, social media, and other platforms as needed.
 - Establish and share metrics to measure project health, community health, and general trends, including:
   - [DevStats](https://spinnaker.devstats.cd.foundation/)
-  - the CDF contribution gamification app [WIP](https://github.com/ExitoLab/spinnaker_gamification_app)
+  - the CDF contribution gamification app [[WIP](https://github.com/ExitoLab/spinnaker_gamification_app)]
   - contributor experience survey(s)
   - engagement on project platforms
   - pull request and issue engagement and closure times

--- a/cx-sig-charter-draft.md
+++ b/cx-sig-charter-draft.md
@@ -40,6 +40,13 @@ We do this by listening - whether it’s through our roadshows to SIG meetings, 
   - engagement on project platforms
 - Research other OSS projects and consult with their leaders about contributor experience topics to make sure we are always delivering value to our contributors
 
+---
+[Nikema's comments (10/15/2020): After reading through what is here, I think the bullet points cover the ways I would want co-lead. I don't have a whole lot to add.]
+
+- Create and maintain subprojects that incentivize community outreach, individual content creation, and welcoming/onboarding of new contributors
+
+---
+
 #### Cross-cutting and Externally Facing Processes
 
 We cross-cut all SIGs and working groups to deliver the following processes:

--- a/cx-sig-charter-draft.md
+++ b/cx-sig-charter-draft.md
@@ -10,14 +10,14 @@ We do this by listening - whether it’s through our roadshows to SIG meetings, 
 
 ### In scope
 
-#### Code, Binaries and Services
+#### Projects & Services
 
 -  In accordance with the code of conduct, establish policies, standards, and procedures for the use, [moderation], and management of all public platforms officially used by the project, including but not limited to:
   - [GitHub Management]
-  - [Mailing lists] / Google groups for the project as a whole (eg: <need community mailing list>@googlegroups.com) and for individual sigs and working groups where the Chairs have provided us ownership
   - [Slack]
   - [/spinnaker] YouTube channel
   - [Zoom]
+- Set up alerting automation for GitHub events, including new contributors, new issues, and new pull requests.
 - Work with other SIGs and interested parties in the project to execute GitHub tasks where required, see [GitHub Management] for more detail
 - Own and execute events that are targeted to the Spinnaker contributor community, including:
   - [Contributor Summit(s)]
@@ -38,16 +38,12 @@ We do this by listening - whether it’s through our roadshows to SIG meetings, 
   - the CDF contribution gamification app [WIP]
   - contributor experience survey(s)
   - engagement on project platforms
+  - pull request and issue engagement and closure times
+- Set community health goals such as improved PR and issue engagement and closure times, and track progress towards their achievement using established metrics.
 - Research other OSS projects and consult with their leaders about contributor experience topics to make sure we are always delivering value to our contributors
-
----
-[Nikema's comments (10/15/2020): After reading through what is here, I think the bullet points cover the ways I would want co-lead. I don't have a whole lot to add.]
-
 - Create and maintain subprojects that incentivize community outreach, individual content creation, and welcoming/onboarding of new contributors
 
----
-
-#### Cross-cutting and Externally Facing Processes
+#### Cross-project and Externally Facing Processes
 
 We cross-cut all SIGs and working groups to deliver the following processes:
 
@@ -82,16 +78,7 @@ This sig adheres to the Roles and Organization Management outlined in Spinnaker'
 
 ### Additional responsibilities of Chairs
 
-Chairs SHOULD plan at least Contributor Experience meeting per year, and should strive to enable annual face to face interaction as conditions allow.
-
-### Additional responsibilities of Tech Leads
-
-Ensuring that technical changes from subprojects follow the process change communication guidelines we establish.
+Chairs SHOULD plan Contributor Experience meetings monthly at the least, and should strive to enable annual face to face interaction as conditions allow. Chairs will also ensure that technical changes from subprojects follow the process change communication guidelines we establish.
 
 ### Deviations from sig-governance
 Six months after this charter is first ratified, it MUST be reviewed and re-approved by the SIG in order to evaluate the assumptions made in its initial drafting.
-
-### Subproject Creation
-Chairs and Technical Leads
-
-[sig-governance]: 

--- a/cx-sig-charter-draft.md
+++ b/cx-sig-charter-draft.md
@@ -82,7 +82,7 @@ CDF in many of the noted cases above contributes funding to our platforms, proce
 
 ## Roles and Organization Management
 
-This sig adheres to the Roles and Organization Management outlined in [sig-governance]
+This sig adheres to the Roles and Organization Management outlined in Spinnaker's governance policy and will actively suggest updates to those policies as part of our work.
 and opts-in to updates and modifications to [sig-governance].
 
 

--- a/cx-sig-charter-draft.md
+++ b/cx-sig-charter-draft.md
@@ -1,10 +1,10 @@
 # Contributor Experience Special Interest Group Charter
 
-This charter adheres to the conventions described in the [Kubernetes Charter README] and uses the Roles and Organization Management outlined in [sig-governance].
+This charter adheres to the conventions described in the [Spinnaker Charter README] and uses the Roles and Organization Management outlined in [sig-governance].
 
 ## Scope
 
-The [Contributor Experience Special Interest Group] (SIG) is responsible for improving the experience of those who upstream contribute to the Kubernetes project. We do this by creating, and maintaining programs and processes that promote community health and reduce project friction, while retiring those programs and processes that don't. Being conscientious of our contributor base is critical to scaling the project, growing the ecosystem, and helping the project succeed.
+The [Contributor Experience Special Interest Group] (SIG) is responsible for improving the experience of those who upstream contribute to the Spinnaker project. We do this by creating, and maintaining programs and processes that promote community health and reduce project friction while retiring those programs and processes that don't. Being conscientious of our contributor base is critical to scaling the project, growing the ecosystem, and helping the project succeed.
 
 We do this by listening - whether it’s through our roadshows to SIG meetings, surveys, data, or [GitHub issues], we take in the feedback and turn it into our [project list]. We build a welcoming and inclusive community of contributors by giving them places to be heard and productive.
 
@@ -12,20 +12,20 @@ We do this by listening - whether it’s through our roadshows to SIG meetings, 
 
 #### Code, Binaries and Services
 
-- Establish policies, standards and procedures for the use, [moderation], and management of all public platforms officially used by the project, including but not limited to:
-  - [discuss.kubernetes.io]
+- Establish policies, standards, and procedures for the use, [moderation], and management of all public platforms officially used by the project, including but not limited to:
+  - [discuss.spinnaker.io]
   - [GitHub Management]
-  - [Mailing lists] / Google groups for the project as a whole (eg: kubernetes-dev@googlegroups.com) and for individual sigs and wgs where the Chairs have provided us ownership
+  - [Mailing lists] / Google groups for the project as a whole (eg: <need community mailing list>@googlegroups.com) and for individual sigs and working groups where the Chairs have provided us ownership
   - [Slack]
-  - [/kubernetescommunity] YouTube channel
+  - [/spinnaker] YouTube channel
   - [Zoom]
 - Establish and staff teams responsible for the administration and moderation of these platforms
   - Teams must be staffed by trusted contributors spanning time zones, see [moderation] for more detail
   - They are authorized to take immediate action when dealing with code of conduct issues, see [moderators] for the full list
   - They are expected to escalate to the project's code of conduct committee when issues rise above the level of simple moderation
 - Work with other SIGs and interested parties in the project to execute GitHub tasks where required, see [GitHub Management] for more detail
-- Own and execute events that are targeted to the Kubernetes contributor community, including:
-  - The weekly [Kubernetes Community meeting]
+- Own and execute events that are targeted to the Spinnaker contributor community, including:
+  - The weekly (or monthly) [Spinnaker Community meeting]
   - [Contributor Summit(s)]
   - [Steering Committee elections] (though we do not own policy creation, see 'out of scope' below)
   - Retrospective moderation for other SIGs upon request
@@ -36,54 +36,55 @@ We do this by listening - whether it’s through our roadshows to SIG meetings, 
   - [Meet Our Contributors]
   - [Group Mentoring - WIP]
   - [The 1:1 Hour - WIP]
-  - Speed Mentoring sessions at selected KubeCon/CloundNativeCon's
-- Help onboard new and current contributors into the culture, workflow, and CI of our contributor experience through the [contributor guide], other related documentation, [contributor summits] and programs tailored to onboarding.
-- Perform issue triage on and maintain the [kubernetes/community] repository.  
+ - [Project Office Hours]
+  - Speed Mentoring sessions at selected Spinnaker/CloundNative/CDFCon's
+- Help onboard new and current contributors into the culture, workflow, and CI of our contributor experience through the [contributor guide], other related documentation, [contributor summits], and programs tailored to onboarding.
+- Perform issue triage on and maintain the [spinnaker/community] repository.  
 - Help SIGs with being as transparent and open as possible through creating best practices, guidelines, and general administration of YouTube, Zoom, and our mailing lists where applicable
 - Assist SIGs/WG Chairs and Technical Leads with organizational management operations as laid out in the [sig-governance] doc
-- Distribute contributor related news on various Kubernetes channels, including Cloud Native Compute Foundation ([CNCF]) for posting blogs, social media, and other platforms as needed.
+- Distribute contributor related news on various Spinnaker channels, including Continous Delivery Foundation ([CDF]) for posting blogs, social media, and other platforms as needed.
 - Establish and share metrics to measure project health, community health, and general trends, including:
-  - ongoing work with the CNCF to improve [DevStats]
+  - ongoing work with the CDF to improve [DevStats]
   - the contributor experience survey(s)
   - engagement on project platforms that we manage
 - Research other OSS projects and consult with their leaders about contributor experience topics to make sure we are always delivering value to our contributors
 
 #### Cross-cutting and Externally Facing Processes
 
-We cross-cut all SIGs and WGs to deliver the following processes:
+We cross-cut all SIGs and working groups to deliver the following processes:
 
 - Deploying Changes:
   When implementing policy changes we strive to balance responding quickly to the needs of the community and ensuring a disruption-free experience for project contributors. As such, the amount of notice we provide and the amount of consensus we seek is driven by our estimation of risk. We don't measure risk objectively at this time, but estimate it based on these parameters:
-  - Low-risk changes impact a small number (<4) of SIGs, WGs, or repos, do not break existing contributor workflows, and are easy to roll back. When implementing low-risk changes we:
-    - Socialize on kubernetes-sig-contribex@googlegroups.com and our weekly update calls
-    - We will go to each lead, their mailing lists, slack channel, and/or their update meetings and ask for feedback and a [lazy consensus] process. We will follow up with a post to [kubernetes-dev@]googlegroups.com mailing list
-  - High-risk changes impact a large number (>4) of SIGs, WGs, or repos, break existing contributor workflows, and are not easy to roll back. When implementing high-risk changes we:
-    - Socialize on kubernetes-sig-contribex@googlegroups.com and our weekly update calls
+  - Low-risk changes impact a small number (<4) of SIGs, working groups, or repositories, do not break existing contributor workflows, and are easy to roll back. When implementing low-risk changes we:
+    - Socialize on <community mailing list>@googlegroups.com and our weekly update calls
+    - We will go to each lead, their mailing lists, slack channel, and/or their update meetings and ask for feedback and a [lazy consensus] process. We will follow up with a post to [<need to figure out what the main mailing list is>@]googlegroups.com mailing list
+  - High-risk changes impact a large number (>4) of SIGs, working group, or repositories, break existing contributor workflows and are not easy to roll back. When implementing high-risk changes we:
+    - Socialize on <we will need community mailing list> and our weekly update calls
     - Seek [lazy consensus] with a time box of at least 72 business hours with a GitHub issue link (or proposal if not applicable) to the following mailing lists:
-        - [kubernetes-sig-contribex@]googlegroups.com
-        - sig-leads@googlegroups.com
-        - [kubernetes-dev@]googlegroups.com with the GitHub issue link including the subject [NOTICE]: $announcement
-        - We will also announce it at the weekly Kubernetes Community Meeting on Thursdays
+        - [<mailinglist>@]googlegroups.com
+        - <sig lead mailing list>@googlegroups.com
+        - [<need to figure out what the main mailing list is>@]googlegroups.com with the GitHub issue link including the subject [NOTICE]: $announcement
+        - We will also announce it at the weekly Spinnaker Community Meeting on <we will need to decide on a day>
 - Depending on how wide of an ecosystem change this is, we may also slack, blog, tweet, and use other channels to get the word out.
 - Our standard time box is 72 business hours; however, there may be situations where we need to act quickly but the time period will always be clear and upfront.
-- Encourage automation to improve productivity for contributors where it makes sense and consult with SIG Testing if automation is covering GitHub workflows.
+- Encourage automation to improve productivity for contributors where it makes sense and consults with SIG Testing if automation is covering GitHub workflows.
 
-If we need funding for any reason, we approach [CNCF].
-CNCF in many of the noted cases above, contributes funding to our platforms, processes, and/or programs. They do not play a day-to-day operations role and have bestowed that to our community to run as we see fit. Since they do fund some of our initiatives, this means that they hold owner account privileges on certain platforms like Zoom and Slack. In these cases, such as Slack, there are at least two Contributor Experience [communication] subproject OWNERs listed as admins.
+If we need funding for any reason, we approach [CDF].
+CDF in many of the noted cases above contributes funding to our platforms, processes, and/or programs. They do not play a day-to-day operations role and have bestowed that to our community to run as we see fit. Since they do fund some of our initiatives, this means that they hold owner account privileges on certain platforms like Zoom and Slack. In these cases, such as Slack, there is at least two Contributor Experience [communication] subproject OWNERs listed as admins.
 
 ### Out of scope
 
 - Code for the testing and CI infrastructure - that’s SIG Testing
-- [kubernetes/community]  ownership of folders for KEPs and Design Proposals. Members are to follow those folders owners files and SIG leadership for the specific issue/PR in question.
+- [spinnaker/community]  ownership of folders for RFCs and Design Proposals. Members are to follow those folder’s owner’s files and SIG leadership for the specific issue/PR in question.
 - User community management. We hold office hours because contributors are a large portion of the volunteers that run that program.
-- The contributor experience for repos not included in the Kubernetes associated repositories list found in the [GitHub Management] subproject README.
+- The contributor experience for repositories not included in the Spinnaker associated repositories lists found in the [GitHub Management] subproject README.
 - Steering committee election policy updates and maintenance.
-- We do not create SIGs/WGs but can assist in the various community management needs of their micro communities that would kick off their formation and keep them going.
-- We are not the [code of conduct committee] and therefore do not control incident management reporting or decisions; however, our moderation guidelines allow us to act swiftly if there is a clear violation of terms of either our code of conduct or one of our supported platforms terms of service. If there is an action that the committee needs to take that involves one of these platforms (example: the removal of someone from GitHub), we will carry that out if none of the committee members have access.
+- We do not create SIGs/working group but can assist in the various community management needs of their micro-communities that would kick off their formation and keep them going.
+- We are not the [code of conduct committee] and therefore do not control incident management reporting or decisions; however, our moderation guidelines allow us to act swiftly if there is a clear violation of terms of either our code of conduct or one of the terms of our supported platform of service. If there is an action that the committee needs to take that involves one of these platforms (example: the removal of someone from GitHub), we will carry that out if none of the committee members have access.
 - Communication platforms that are out of our scope for maintenance and support but we may still have some influence:
-    - [r/kubernetes]
-    - [@kubernetesio] twitter account
-    - [kubernetes blog]
+    - [r/spinnaker]
+    - [@spinnaker] twitter account
+    - [spinnaker blog]
 
 ## Roles and Organization Management
 
@@ -105,38 +106,5 @@ Six months after this charter is first ratified, it MUST be reviewed and re-appr
 ### Subproject Creation
 Chairs and Technical Leads
 
-[sig-governance]: https://git.k8s.io/community/committee-steering/governance/sig-governance.md
-[Kubernetes Charter README]: https://git.k8s.io/community/committee-steering/governance/README.md
-[lazy consensus]: http://en.osswiki.info/concepts/lazy_consensus
-[Contributor Experience Special Interest Group]: https://groups.google.com/forum/#!forum/kubernetes-sig-contribex
-[kubernetes-dev@]: https://groups.google.com/forum/#!forum/kubernetes-dev
-[@kubernetesio]: https://www.twitter.com/kubernetesio
-[r/kubernetes]: https://kubernetes.reddit.com
-[Google Summer of Code]: https://git.k8s.io/community/mentoring/google-summer-of-code.md
-[Outreachy]: https://git.k8s.io/community/mentoring/outreachy.md
-[Meet Our Contributors]:  https://git.k8s.io/community/mentoring/meet-our-contributors.md
-[Group Mentoring - WIP]:  https://git.k8s.io/community/mentoring/group-mentoring.md
-[The 1:1 Hour - WIP]: https://git.k8s.io/community/mentoring/the1-on-1hour.md
-[kubernetes/community]: https://git.k8s.io/community/
-[Contributor Summit(s)]: https://git.k8s.io/community/events/2018/12-contributor-summit
-[contributor summits]: https://git.k8s.io/community/events/2018/12-contributor-summit
-[DevStats]: https://k8s.cncf.devstats.io
-[kubernetes-sig-contribex@]: https://groups.google.com/forum/#!forum/kubernetes-sig-contribex
-[kubernetes blog]: https://www.kubernetes.io/blog
-[GitHub Management]: https://git.k8s.io/community/github-management
-[communication]: https://git.k8s.io/community/communication
-[CNCF]: https://cncf.io
-[GitHub issues]: https://github.com/kubernetes/community/issues
-[project list]: https://github.com/orgs/kubernetes/projects/1
-[Kubernetes Community meeting]: https://git.k8s.io/community/communication#weekly-meeting
-[mentoring programs]: https://git.k8s.io/community/mentoring
-[Steering Committee elections]: https://git.k8s.io/community/events/elections
-[Slack]: https://git.k8s.io/community/communication/slack-guidelines.md
-[Zoom]: https://git.k8s.io/community/communication/zoom-guidelines.md
-[/kubernetescommunity]: https://www.youtube.com/kubernetescommunity
-[discuss.kubernetes.io]: https://discuss.kubernetes.io
-[contributor guide]: https://git.k8s.io/community/contributor
-[moderation]: https://git.k8s.io/community/communication/moderation.md
-[code of conduct committee]: https://git.k8s.io/community/committee-code-of-conduct
-[Mailing lists]: https://git.k8s.io/community/communication/moderation.md#specific-guidelines
-[moderators]: https://git.k8s.io/community/communication/moderators.md
+[sig-governance]: 
+

--- a/cx-sig-charter-draft.md
+++ b/cx-sig-charter-draft.md
@@ -80,7 +80,6 @@ CDF in many of the noted cases above contributes funding to our platforms, proce
 - Communication platforms that are out of our scope for maintenance and support but we may still have some influence:
     - [r/spinnaker]
     - [@spinnaker] twitter account
-    - [spinnaker blog]
 
 ## Roles and Organization Management
 

--- a/cx-sig-charter-draft.md
+++ b/cx-sig-charter-draft.md
@@ -12,7 +12,7 @@ We do this by listening - whether it’s through our roadshows to SIG meetings, 
 
 #### Code, Binaries and Services
 
-- Establish policies, standards, and procedures for the use, [moderation], and management of all public platforms officially used by the project, including but not limited to:
+-  In accordance with the code of conduct, establish policies, standards, and procedures for the use, [moderation], and management of all public platforms officially used by the project, including but not limited to:
   - [GitHub Management]
   - [Mailing lists] / Google groups for the project as a whole (eg: <need community mailing list>@googlegroups.com) and for individual sigs and working groups where the Chairs have provided us ownership
   - [Slack]
@@ -20,28 +20,24 @@ We do this by listening - whether it’s through our roadshows to SIG meetings, 
   - [Zoom]
 - Work with other SIGs and interested parties in the project to execute GitHub tasks where required, see [GitHub Management] for more detail
 - Own and execute events that are targeted to the Spinnaker contributor community, including:
-  - The weekly (or monthly) [Spinnaker Community meeting]
   - [Contributor Summit(s)]
-  - [Steering Committee elections] (though we do not own policy creation, see 'out of scope' below)
+  -[Gardening Days and hackathons]
   - Retrospective moderation for other SIGs upon request
   - Other events, like other SIG face to face events, upon request and consideration
 - Strategize, build, and execute on scalable [mentoring programs] for all contributor levels. These may include:
   - [Google Summer of Code]
   - [Outreachy]
-  - [Meet Our Contributors]
-  - [Group Mentoring - WIP]
-  - [The 1:1 Hour - WIP]
- - [Project Office Hours]
-  - Speed Mentoring sessions at selected Spinnaker/CloundNative/CDFCon's
+- New mentoring programs: office hours, meet the contributors, 1:1 pairing, group mentoring, etc.
 - Help onboard new and current contributors into the culture, workflow, and CI of our contributor experience through the [contributor guide], other related documentation, [contributor summits], and programs tailored to onboarding.
-- Perform issue triage on and maintain the [spinnaker/community] repository.  
+- Perform issue triage on and maintain the [spinnaker/contributor-experience] repository.  
 - Help SIGs with being as transparent and open as possible through creating best practices, guidelines, and general administration of YouTube, Zoom, and our mailing lists where applicable
-- Assist SIGs/WG Chairs and Technical Leads with organizational management operations as laid out in the [sig-governance] doc
+- Document and assist SIGs/WG Chairs and Technical Leads with organizational management operations
 - Distribute contributor related news on various Spinnaker channels, including Continous Delivery Foundation ([CDF]) for posting blogs, social media, and other platforms as needed.
 - Establish and share metrics to measure project health, community health, and general trends, including:
-  - ongoing work with the CDF to improve [DevStats]
-  - the contributor experience survey(s)
-  - engagement on project platforms that we manage
+  - [DevStats]
+  - the CDF contribution gamification app [WIP]
+  - contributor experience survey(s)
+  - engagement on project platforms
 - Research other OSS projects and consult with their leaders about contributor experience topics to make sure we are always delivering value to our contributors
 
 #### Cross-cutting and Externally Facing Processes
@@ -49,36 +45,28 @@ We do this by listening - whether it’s through our roadshows to SIG meetings, 
 We cross-cut all SIGs and working groups to deliver the following processes:
 
 - Deploying Changes:
-  When implementing policy changes we strive to balance responding quickly to the needs of the community and ensuring a disruption-free experience for project contributors. As such, the amount of notice we provide and the amount of consensus we seek is driven by our estimation of risk. We don't measure risk objectively at this time, but estimate it based on these parameters:
+ This SIG will create change-deployment policies that balance quick response to the needs of the community and a limit on disruptions for project contributors. We will create policies to socialize and elicit feedback on changes via community channels such as Slack, spinnaker.io, Twitter, mailing lists, SIG meetings, delegating to SIG leads, etc. The amount of notice we provide and the amount of consensus we seek is driven by our estimation of risk. We can estimate risk based on these parameters:
+ 
+- Low-risk changes impact a small number (<3) of SIGs, working groups, or repositories, do not break existing contributor workflows, and are easy to roll back.
+- High-risk changes impact a large number (>3) of SIGs, working groups, or repositories, break existing contributor workflows and are not easy to roll back.
   - Low-risk changes impact a small number (<4) of SIGs, working groups, or repositories, do not break existing contributor workflows, and are easy to roll back. When implementing low-risk changes we:
-    - Socialize on <community mailing list>@googlegroups.com and our weekly update calls
-    - We will go to each lead, their mailing lists, slack channel, and/or their update meetings and ask for feedback and a [lazy consensus] process. We will follow up with a post to [<need to figure out what the main mailing list is>@]googlegroups.com mailing list
-  - High-risk changes impact a large number (>4) of SIGs, working group, or repositories, break existing contributor workflows and are not easy to roll back. When implementing high-risk changes we:
-    - Socialize on <we will need community mailing list> and our weekly update calls
-    - Seek [lazy consensus] with a time box of at least 72 business hours with a GitHub issue link (or proposal if not applicable) to the following mailing lists:
-        - [<mailinglist>@]googlegroups.com
         - <sig lead mailing list>@googlegroups.com
         - [<need to figure out what the main mailing list is>@]googlegroups.com with the GitHub issue link including the subject [NOTICE]: $announcement
         - We will also announce it at the weekly Spinnaker Community Meeting on <we will need to decide on a day>
 - Depending on how wide of an ecosystem change this is, we may also slack, blog, tweet, and use other channels to get the word out.
 - Our standard time box is 72 business hours; however, there may be situations where we need to act quickly but the time period will always be clear and upfront.
-- Encourage automation to improve productivity for contributors where it makes sense and consults with SIG Testing if automation is covering GitHub workflows.
+- Encourage automation to improve productivity for contributors where it makes sense, and consult with SIG leads on automation workflows.
 
 If we need funding for any reason, we approach [CDF].
-CDF in many of the noted cases above contributes funding to our platforms, processes, and/or programs. They do not play a day-to-day operations role and have bestowed that to our community to run as we see fit. Since they do fund some of our initiatives, this means that they hold owner account privileges on certain platforms like Zoom and Slack. In these cases, such as Slack, there is at least two Contributor Experience [communication] subproject OWNERs listed as admins.
+CDF may contribute funding to our platforms, processes, and/or programs. They do not play a day-to-day operations role and have bestowed that to our community to run as we see fit. Since they do fund some of our initiatives, this means that they hold owner account privileges on certain platforms like Zoom and Slack. The CX SIG will work to ensure that project maintainers are included as admins.
 
 ### Out of scope
 
-- Code for the testing and CI infrastructure - that’s SIG Testing
-- [spinnaker/community]  ownership of folders for RFCs and Design Proposals. Members are to follow those folder’s owner’s files and SIG leadership for the specific issue/PR in question.
-- User community management. We hold office hours because contributors are a large portion of the volunteers that run that program.
-- The contributor experience for repositories not included in the Spinnaker associated repositories lists found in the [GitHub Management] subproject README.
-- Steering committee election policy updates and maintenance.
+- Code for the testing and CI infrastructure
+- User community management.
+- The contributor experience for repositories not included in the Spinnaker organization
 - We do not create SIGs/working group but can assist in the various community management needs of their micro-communities that would kick off their formation and keep them going.
-- We are not the [code of conduct committee] and therefore do not control incident management reporting or decisions; however, our moderation guidelines allow us to act swiftly if there is a clear violation of terms of either our code of conduct or one of the terms of our supported platform of service. If there is an action that the committee needs to take that involves one of these platforms (example: the removal of someone from GitHub), we will carry that out if none of the committee members have access.
-- Communication platforms that are out of our scope for maintenance and support but we may still have some influence:
-    - [r/spinnaker]
-    - [@spinnaker] twitter account
+- We are not a [code of conduct committee] and therefore do not control incident management reporting or decisions; however, our mission includes acting swiftly if there is a clear violation of either our code of conduct or one of the terms of our supported platform of service.
 
 ## Roles and Organization Management
 

--- a/cx-sig-charter-draft.md
+++ b/cx-sig-charter-draft.md
@@ -4,7 +4,7 @@ This charter adheres to the conventions described in the [Spinnaker Charter READ
 
 ## Scope
 
-The [Contributor Experience Special Interest Group] (SIG) is responsible for improving the experience of those who upstream contribute to the Spinnaker project. We do this by creating, and maintaining programs and processes that promote community health and reduce project friction while retiring those programs and processes that don't. Being conscientious of our contributor base is critical to scaling the project, growing the ecosystem, and helping the project succeed.
+The [Contributor Experience Special Interest Group] (SIG) is responsible for improving the experience of those who contribute upstream to the Spinnaker project. We do this by creating, and maintaining programs and processes that promote community health and reduce project friction while retiring those programs and processes that don't. Being conscientious of our contributor base is critical to scaling the project, growing the ecosystem, and helping the project succeed.
 
 We do this by listening - whether it’s through our roadshows to SIG meetings, surveys, data, or [GitHub issues], we take in the feedback and turn it into our [project list]. We build a welcoming and inclusive community of contributors by giving them places to be heard and productive.
 

--- a/cx-sig-charter-draft.md
+++ b/cx-sig-charter-draft.md
@@ -87,7 +87,7 @@ This sig adheres to the Roles and Organization Management outlined in Spinnaker'
 
 ### Additional responsibilities of Chairs
 
-Chairs SHOULD plan at least one face to face Contributor Experience meeting per year
+Chairs SHOULD plan at least Contributor Experience meeting per year, and should strive to enable annual face to face interaction as conditions allow.
 
 ### Additional responsibilities of Tech Leads
 

--- a/cx-sig-charter-draft.md
+++ b/cx-sig-charter-draft.md
@@ -18,7 +18,6 @@ We do this by listening - whether it’s through our roadshows to SIG meetings, 
   - [Slack]
   - [/spinnaker] YouTube channel
   - [Zoom]
-  - They are authorized to take immediate action when dealing with code of conduct issues, see [moderators] for the full list
   - They are expected to escalate to the project's code of conduct committee when issues rise above the level of simple moderation
 - Work with other SIGs and interested parties in the project to execute GitHub tasks where required, see [GitHub Management] for more detail
 - Own and execute events that are targeted to the Spinnaker contributor community, including:

--- a/cx-sig-charter-draft.md
+++ b/cx-sig-charter-draft.md
@@ -18,7 +18,6 @@ We do this by listening - whether it’s through our roadshows to SIG meetings, 
   - [Slack]
   - [/spinnaker] YouTube channel
   - [Zoom]
-  - They are expected to escalate to the project's code of conduct committee when issues rise above the level of simple moderation
 - Work with other SIGs and interested parties in the project to execute GitHub tasks where required, see [GitHub Management] for more detail
 - Own and execute events that are targeted to the Spinnaker contributor community, including:
   - The weekly (or monthly) [Spinnaker Community meeting]

--- a/cx-sig-charter-draft.md
+++ b/cx-sig-charter-draft.md
@@ -18,7 +18,6 @@ We do this by listening - whether it’s through our roadshows to SIG meetings, 
   - [Slack]
   - [/spinnaker] YouTube channel
   - [Zoom]
-- Establish and staff teams responsible for the administration and moderation of these platforms
   - Teams must be staffed by trusted contributors spanning time zones, see [moderation] for more detail
   - They are authorized to take immediate action when dealing with code of conduct issues, see [moderators] for the full list
   - They are expected to escalate to the project's code of conduct committee when issues rise above the level of simple moderation

--- a/cx-sig-charter-draft.md
+++ b/cx-sig-charter-draft.md
@@ -91,7 +91,7 @@ Chairs SHOULD plan at least Contributor Experience meeting per year, and should 
 
 ### Additional responsibilities of Tech Leads
 
-Ensuring that technical changes from subprojects follow the process change communication guidelines listed above.
+Ensuring that technical changes from subprojects follow the process change communication guidelines we establish.
 
 ### Deviations from sig-governance
 Six months after this charter is first ratified, it MUST be reviewed and re-approved by the SIG in order to evaluate the assumptions made in its initial drafting.

--- a/cx-sig-proposed-README.md
+++ b/cx-sig-proposed-README.md
@@ -1,0 +1,1 @@
+# Contributor Experience SIG

--- a/cx-sig-proposed-README.md
+++ b/cx-sig-proposed-README.md
@@ -1,1 +1,29 @@
-# Contributor Experience SIG
+# Spinnaker Contributor Experience Special Interest Group
+
+## Meeting Info
+* Weekly on Thursdays at 10 AM US/Pacific ([See in your time zone](https://www.thetimezoneconverter.com/?t=10am&tz=San%20Francisco))
+* [Agenda and notes](https://hackmd.io/@spinnaker-cx/ry03Vk6LP)
+* [Meeting link]
+
+## Roles & Responsibilities of the SIG Leads
+
+### SIG Lead(s):
+
+**[Ige Adetokunbo Temitayo](https://github.com/ExitoLabs)**  
+DevOps and Site Reliability Engineer at Emirates Group
+
+**[Nikema Prophet](https://github.com/prophen)**  
+Associate Community Marketing Manager at Armory
+
+### SIG Lead Responsibility
+
+* Coordinate communication.
+* Set meeting dates and objectives for the coming year.
+* Curate agenda for each meeting.
+* Raise awareness of needs of current and potential contributors and invite appropriate participants.
+* Encourage and foster an inclusive environment.
+* Identify and develop resources (people or funding) in support of enhancing contributor experience for Spinnaker.
+
+# Responsibilities
+
+See [Contributor Experience Charter] for description, scope of work and goals.


### PR DESCRIPTION
Bring in the text from https://github.com/kubernetes/community/blob/master/sig-contributor-experience/charter.md to use as a base for Spinnaker CX SIG charter