### PR TITLE
Design doc for Awaiting judgment filter and one click navigation to leaf node

### DIFF
--- a/rfc/manual.md
+++ b/rfc/manual.md
@@ -1,0 +1,85 @@
+# Select roles that can execute manual judgment stage
+
+| | |
+|-|-|
+| *Status* | *Proposed*, Accepted, Implemented, Obsolete |
+| *RFC #* | https://github.com/spinnaker/deck/pull/8700
+| *Author(s)* | Rumit Rout (@rumit-opsmx) (https://github.com/rumit-opsmx) | Rajinder Siddhu (@siddhu-opsmx) (https://github.com/siddhu-opsmx)
+| *SIG / WG* | sig-ux
+
+## Overview
+
+If there are many pipelines it may be difficult for the user to serially check all the pipelines that are waiting for manual judgement. So we need a functionality which will filter out all the pipelines that require manual intervention.
+
+To implement such a feature we added a stage filter ( Manual Judgement ) that filters the pipelines based on if any of the pipelines are waiting on manual judgement also add a visual notification for the stages that are waiting on manual judgement and on clicking on these stages will take you to the leaf child of the pipeline stage which is actually waiting on the manual judgement.
+
+
+### Goals and Non-Goals
+
+Add a filter for filtering pipelines waiting on manual judgment. Checking this filter will automatically select the running stage filter and disable it(since all manual judjement pipelines are running). on deselecting the manual judgment filter the running filter will be enabled but still selected.
+
+There will be a visual indication on all the stages that are waiting on manual judgment and on clicking on the stage will take you to the root pipeline waiting on manual judgment.
+
+
+
+## Motivation and Rationale
+
+If there are many pipelines it may be difficult for the user to serially check all the pipelines that are waiting for manual judgement. We need an Easy way to filter for pipelines waiting on Manual Judgment.
+
+If we have a pipeline that is waiting on manual judgement then all the other pipelines that are waiting for this pipeline to be executed will be in the waiting stage. Clicking on any of the waiting stages will directly take you to the pipeline waiting on manual judgment.
+
+
+
+## Timeline
+
+Already Implemented
+
+## Design
+
+1. Enhanced FilterModelService.ts to
+
+added a filter tag for manual judgment and enhanced the clear filter functionality to clear manual judgment filter.
+
+2. Enhanced IFilterModel to
+
+added filterStages and stages to ISortFilter
+
+3. Enhanced Execution.tsx to
+
+added goToParent and manualJudgment to IExecutionProps
+added a finalChild function that recursively finds the final child pipeline waiting on manual judgment.
+
+4. Enhanced ExecutionMarker.tsx  to
+
+Added a manual judgment status whether the stage’s child pipeline is waiting on manual Judgment.
+Added the functionality so when a stage whose child pipeline is waiting on manual judgment is clicked then it scrolls to the leaf pipeline waiting on the manual judgment.
+
+5. Enhanced executionMarker.less to
+
+added a visual indicator to the stages waiting on manual judgment.
+
+5. Enhanced ExecutionGroups.tsx to
+
+added an id to the Execution group level so that we can scroll to the execution group in case the execution group is collapsed.
+
+6. Enhanced ExecutionGroup.tsx  to
+
+added a function to go to root pipeline waiting on manual judgment. if the execution group is collapsed then it will move the focus to the execution group header instead.
+created a function to filter all the executions that contain manual judgement
+Created a object containing all executions that are waiting on manual judgment and it's immidiate child
+
+7. Enhanced ExecutionFilterModel.ts to 
+added a filterstages property to sortfilter to extend the functionality and to reuse the same object to add other filters to the stages in future.
+
+8. Enhanced ExecutionFilters.tsx to 
+created a new component to be used for stage filter for filtering Manual Judgment filter. it can be reused to add more stage filter in the future.
+
+9. Enhanced executionFilter.service.ts to 
+
+enhance the clearFilters function to clear all the stageFilters also.
+
+10. Enhanced ProjectPipeline.tsx to
+
+add a default value to support the scroll to leaf if pipeline is waiting on manual judgment functionality.
+
+Rest of the changes are related to passing props to corresponding components.


### PR DESCRIPTION


https://user-images.githubusercontent.com/72563935/106610189-76ecf680-658c-11eb-84d7-5f086947b891.mp4


## Manual Judgement Navigation Enhancement

| **Status**        | **Proposed**, Accepted, Implemented, Obsolete           |
| ------------- |-------------|
|  **RFC #**      | [spinnaker/deck#8818](https://github.com/spinnaker/deck/pull/8818) | 
| **Author(s)**      | 	[Rumit Rout (@rumit-opsmx)](https://github.com/rumit-opsmx), [Rajinder Siddhu (@siddhu-opsmx)](https://github.com/siddhu-opsmx)      | 
| **SIG / WG** | sig-ui     | 

## Overview

If there are many pipelines it may be difficult for the user to serially check all the pipelines that are waiting for manual judgement. So we need a functionality which will filter out all the pipelines that require manual intervention.

To implement such a feature we added a stage filter ( Manual Judgement ) that filters the pipelines based on if any of the pipelines are waiting on manual judgement also add a visual notification for the stages that are waiting on manual judgement and on clicking on these stages will take you to the leaf child of the pipeline stage which is actually waiting on the manual judgement.


### Goals and Non-Goals

Add a filter for filtering pipelines waiting on manual judgment. Checking this filter will automatically select the running stage filter and disable it(since all manual judgement pipelines are running). on deselecting the manual judgment filter the running filter will be enabled but still selected.

There will be a visual indication on all the stages that are waiting on manual judgment and clicking on the stage will take you to the root pipeline waiting on manual judgment.


## Motivation and Rationale

If there are many pipelines it may be difficult for the user to serially check all the pipelines that are waiting for manual judgement. We need an Easy way to filter for pipelines waiting on Manual Judgment.

If we have a pipeline that is waiting on manual judgement then all the other pipelines that are waiting for this pipeline to be executed will be in the waiting stage. Clicking on any of the waiting stages will directly take you to the pipeline waiting on manual judgment.

## Problem Definition:

1. If there are many pipelines it may be difficult for the user to serially check all the pipelines that are 
    waiting for manual judgement. We need an Easy way to filter for pipelines waiting on manual 
    Judgment.
2. If we have a pipeline that is waiting on manual judgement then all the other pipelines that are 
    waiting for this pipeline to be executed will be in the waiting stage. Clicking on any of the waiting    
    stages will directly take you to the pipeline waiting on manual judgment.

## Approach



**1.1 Added a filter in the status block of the filter section.**
![Manual Judgment Filter](https://drive.google.com/uc?export=view&id=1CrxaWFQWjSuQpM0J0qPPixhB6MX9se1_)
Fig: 1.1  Add a manual judgment filter.

**1.2. Operations on Manual Judgment filter (onSelect).**
![Manual Judgment Filter View](https://drive.google.com/uc?export=view&id=1-LFkEDaM5rO4h0FZSkfTnPhv5xRLC4qm)
Add a filter for filtering pipelines waiting on manual judgement. Checking this filter will automatically select the running stage filter and disable it(since all manual judgement pipelines are running).
    1.2.1 Selecting Manual Judgment filter.
    1.2.2 Checking Manual Judgment filter will automatically select the running stage filter and disable it.
    1.2.3 Add a tag in the Filter by section to indicate whether the manual judgment filter is checked or not.

**1.3. Operations on Manual Judgment filter (onDeselect).**
![Manual Judgment Filter Uncheck](https://drive.google.com/uc?export=view&id=1rBMS5-k-y18XZwKblFP6CvCcPRabShLM)
On deselecting the manual judgement filter the running filter will be enabled but still selected. Users can deselect Manual Judgment filters using the side-bar or from the tag section or by using clear all.
    1.3.1 On deselecting the manual judgement filter the running filter will be enabled but still selected.
    1.3.2 The executions will be filtered as per remaining applied filters.

***

**2.1 Added a visual indication to the stages waiting on Manual Judgment.**
![Manual Judgment Filter Uncheck](https://drive.google.com/uc?export=view&id=18M1B0XheVNTVPebITNFmeWWquEi3K_D5)
    2.1.1 Added a manual judgment status whether the stage’s child pipeline is waiting on manual Judgment.
    2.1.2 Added the functionality so when a stage whose child pipeline is waiting on manual judgment is clicked then it   
             scrolls to the leaf pipeline waiting on the manual judgment.

**2.2 Detail execution view behaviour.**
![Manual Judgment Filter Uncheck](https://drive.google.com/uc?export=view&id=1suT3g3k1BoF385_wlL9kHbMH_AmoLB_d)
    2.2.1 On Clicking on the waiting stage it will scroll to the leaf node as shown in figure and if the execution group is collapsed it   
    will move the focus to the execution group header. 
    2.2.2 You will see that the leaf stage that is waiting on manual judgement shows manual judgment and on clicking on the stage  
    you can view the default detailed view of the pipeline execution.

**2.3 Once the leaf node is successful it will be reflected in the parent pipelines and the waiting status will be removed.**
![Manual Judgment Filter Uncheck](https://drive.google.com/uc?export=view&id=1Ig6vDht_ddr3dmByp8TM5uFVUbWHYmO_)
    2.3.1 Shows waiting because one of the child pipelines is waiting on manual judgment.
    2.3.2 shows the successful execution because it is no longer waiting on manual judgment.

***


**3.1 Redirecting to leaf node view which is waiting on the manual judgement.**![One Click Navigation](https://drive.google.com/uc?export=view&id=1Xxq8PFfqp6VQ2aY974S5jqNuzzGRc4y0)
     3.3.1 Showing the application name of the leaf node waiting on manual judgement triggered by 
             deploy_dev1_uswest2_core003_sdb1-cell-aggregate from the sdsd application.
     3.3.2 Showing testdemo24 pipeline execution which is not the immediate child of deploy_dev1_uswest2_core003_sdb1-   
              cell-aggregate from the sdsd application.
     3.3.3 The testdemo24 pipeline is waiting on manual judgment, So after taking manual action on it ,will update the status 
              of the root pipeline which exists in another application(i.e, sdsd).
     3.3.4 Clicking on the back button will take you back to the root application.

 **Below fig is reflecting the updated status of the stage in root application.**![One Click Navigation](https://drive.google.com/uc?export=view&id=172HlPKHbLRya-rBQ51Gw9gYqd8cYbxCb)
      FIg::
             1. indicates the application name of the root execution.
             2. Indicates the updated status of the stage after performing manual action on each child pipeline waiting on 
                 manual judgement
             3. Indicates the child execution status as also succeeded.



> #### Note::  you can enable or disable the manual judgement feature flag in the env file using the variable MANUAL_JUDGEMENT_ENABLED to true or false.














