### PR TITLE
Additional Azure SIG lead

### DIFF
--- a/sig-azure/README.md
+++ b/sig-azure/README.md
@@ -12,6 +12,9 @@ _Salesforce_
 Principal Software Engineer \
 _Salesforce_
 
+**[Mark Gray](https://github.com/grayzu)** \
+Senior Program Manager
+_Microsoft_
 
 ### SIG Lead Responsibility
 


### PR DESCRIPTION
Add myself as SIG co-lead after successful nomination in 11/10/2020 Azure SIG meeting.