### PR TITLE
chore(k8s-sig): SIG lead change for Kubernetes SIG

### DIFF
--- a/sig-kubernetes/README.md
+++ b/sig-kubernetes/README.md
@@ -12,7 +12,7 @@ The Kubernetes SIG is responsible for the integration between Spinnaker and Kube
 ## Leadership
 
 * German Muzquiz ([german-muzquiz](https://github.com/german-muzquiz))
-* Eric Zimanyi ([ezimanyi](https://github.com/ezimanyi))
+* Chuck Lane ([clanesf](https://github.com/clanesf))
 
 ## Contact
 


### PR DESCRIPTION
I'd like to propose @clanesf to co-lead the Kubernetes SIG. He has made contributions in the past and I think he will do a good job helping lead the SIG.