### PR TITLE
chore(core): Remove ezimanyi as TOC member

### DIFF
--- a/.github/ISSUE_TEMPLATE/approver-application.md
+++ b/.github/ISSUE_TEMPLATE/approver-application.md
@@ -3,7 +3,7 @@ name: Approver Application
 about: Request OSS Approver status
 title: 'REQUEST: New Approver status for <your-GH-username>'
 labels: committee/technical-oversight
-assignees: ajordens, ethanfrogers, ezimanyi, plumpy, robzienert
+assignees: ajordens, ethanfrogers, plumpy, robzienert
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/new-cloud-provider.md
+++ b/.github/ISSUE_TEMPLATE/new-cloud-provider.md
@@ -3,7 +3,7 @@ name: New Cloud Provider
 about: Propose the addition of a new Cloud Provider
 title: 'PROPOSAL: New Cloud Provider for <cloud provider name>'
 labels: committee/technical-oversight
-assignees: ajordens, ethanfrogers, ezimanyi, plumpy, robzienert
+assignees: ajordens, ethanfrogers, plumpy, robzienert
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/reviewer-application.md
+++ b/.github/ISSUE_TEMPLATE/reviewer-application.md
@@ -3,7 +3,7 @@ name: Reviewer Application
 about: Request OSS Reviewer status
 title: 'REQUEST: New Reviewer status for <your-GH-username>'
 labels: committee/technical-oversight
-assignees: ajordens, ethanfrogers, ezimanyi, plumpy, robzienert
+assignees: ajordens, ethanfrogers, plumpy, robzienert
 
 ---
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-*                       @ajordens @robzienert @plumpy @ezimanyi @ethanfrogers
+*                       @ajordens @robzienert @plumpy @ethanfrogers
 commitee-steering.md    @aglover @duftler @demobox @pstout @Emkidwell
 code-of-conduct.md      @aglover @duftler @demobox @pstout @Emkidwell
 governance.md           @aglover @duftler @demobox @pstout @Emkidwell

--- a/committee-technical-oversight/README.md
+++ b/committee-technical-oversight/README.md
@@ -16,7 +16,6 @@
 
 * @ajordens (Netflix)
 * @ethanfrogers (Armory)
-* @ezimanyi (Google)
 * @plumpy (Google)
 * @robzienert (Netflix) (Chair)
 


### PR DESCRIPTION
As previously announced, I'll be stepping away from the Spinnaker project and thus stepping down from the TOC effective today. This commit removes me from the various places where I am referenced as a member of the TOC.