### PR TITLE
Remove duplicate Steering Committee membership.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 *                       @ajordens @plumpy
-commitee-steering.md    @aglover @duftler @demobox @pstout @Emkidwell
-code-of-conduct.md      @aglover @duftler @demobox @pstout @Emkidwell
-governance.md           @aglover @duftler @demobox @pstout @Emkidwell
+commitee-steering.md    @duftler @emagana @imosquera @pauljrob @pstout
+code-of-conduct.md      @duftler @emagana @imosquera @pauljrob @pstout
+governance.md           @duftler @emagana @imosquera @pauljrob @pstout

--- a/committee-steering/README.md
+++ b/committee-steering/README.md
@@ -9,16 +9,16 @@ _TODO_
 * Regular Meeting
   * [Agenda](https://docs.google.com/document/d/1HMdwvBPM4uRFqoeAd7eEkVWIC8dQP40zFavOE5Kq-Eg/edit)
 
-
 ## Members
 
-* Andy Glover (Netflix)
-* Matt Duftler (Google)
-* Peter Stout (Netflix)
-* Isaac Mosquera (Armory)
-* Andrew Phillips (Google)
+<!-- When updating this list, make sure to also update CODEOWNERS -->
+
+* [Edgar Magana](https://github.com/emagana) (Splunk) - Term expires 2023.01.31
+* [Isaac Mosquera](https://github.com/imosquera) (Armory) - Term expires 2022.01.31
+* [Matt Duftler](https://github.com/duftler) (Netflix) - Term expires 2022.01.31
+* [Paul Roberts](https://github.com/pauljrob) (AWS) - Term expires 2023.01.31
+* [Peter Stout](https://github.com/pstout) (Netflix) - Chair - Term expires 2022.01.31
 
 ## Contact
 
-* Mailing List
-* Private Email: [mailto:sc@spinnaker.io](sc@spinnaker.io)
+* Private Email: [sc@spinnaker.io](mailto:sc@spinnaker.io)

--- a/committee-technical-oversight/README.md
+++ b/committee-technical-oversight/README.md
@@ -14,9 +14,11 @@
 
 ## Members
 
-* @ajordens (Netflix)
-* @plumpy (Google)
+<!-- When updating this list, make sure to also update CODEOWNERS -->
+
+* [Adam Jordens](https://github.com/ajordens) (Netflix)
+* [Michael Plump](https://github.com/plumpy) (Google)
 
 ## Contact
 
-* Private Email: [mailoto:toc@spinnaker.io](toc@spinnaker.io)
+* Private Email: [toc@spinnaker.io](mailto:toc@spinnaker.io)

--- a/governance.md
+++ b/governance.md
@@ -91,7 +91,7 @@ Qualifications
   
 Election to the TOC requires a majority of the SC. 
 
-[Technical Oversight Committee](committee-technical-oversight/README.md)
+[Technical Oversight Committee membership and meeting information](committee-technical-oversight/README.md)
 
 The TOC will have three, five, or seven members, as deemed appropriate by the Steering Committee. In the event that someone from the TOC leaves during their term, the Steering Committee shall appoint someone to fill the remainder of the term. Each year, the TOC will nominate a member to serve as the Chairperson for that year. The Chair's duties will include calling and runnings meetings, calling votes, and ensuring that meeting notes are recorded. 
 
@@ -114,18 +114,7 @@ Qualifications:
 
 ^ - SC members whose terms were extended by one month when the terms were shifted from starting January 1st to starting February 1st may serve 4 years and one month consecutively.
 
-Logistics
-
-* [Agenda doc](https://docs.google.com/document/d/1HMdwvBPM4uRFqoeAd7eEkVWIC8dQP40zFavOE5Kq-Eg/edit)
-* Email: [sc@spinnaker.io](mailto:sc@spinnaker.io)
-
-Current SC members:
-
-* Edgar Magana (Salesforce) - Term expires 2023.01.31
-* Isaac Mosquera (Armory) - Term expires 2022.01.31
-* Matt Duftler (Google) - Term expires 2022.01.31
-* Paul Roberts (AWS) - Term expires 2023.01.31
-* Peter Stout (Netflix) - Chair - Term expires 2022.01.31
+[Steering Committee membership and meeting information](committee-steering/README.md)
 
 Election to the SC requires a majority of the SC. If a person is up for reelection they are not allowed to vote for their reelection. 
 


### PR DESCRIPTION
One of them was out of date. Also fixed the outdated list in CODEOWNERS.

Also: updated the employers of Edgar and Matt, added some links, etc.