### PR TITLE
fix(sig): Removed bouncing email user & Fix notes links

### DIFF
--- a/sig-security/README.md
+++ b/sig-security/README.md
@@ -10,13 +10,12 @@ Core responsibilities include:
 
 * Regular SIG Meeting
   * Every other Thursday, 11 AM US/Pacific ([See in your time zone](https://www.thetimezoneconverter.com/?t=11am&tz=San%20Francisco))
-  * [Agenda](https://docs.google.com/document/d/1GhzhmG7ZytJBfW2lontOSBxVghgNZmxstF49SoocTDQ/edit#heading=h.ilm7rdxf4d42)
+  * [Agenda](https://docs.google.com/document/d/1BaaxjHGybhFjrYrIk7t0QWRMCg44A-i1EJ9Qc321QLk/edit?usp=sharing)
 
 ## Leadership
 
 * Jason McIntosh ([jasonmcintosh](https://github.com/jasonmcintosh/))
 * Brian Newton ([bnewtonius](https://github.com/bnewtonius/))
-* Shaun Phillips ([shaun-phillips](https://github.com/shaun-phillips))
 
 ## Contact
 


### PR DESCRIPTION
Old agenda notes appear to have been deleted.  It's unknown who the original owner was.  Also removing non-existing user.  AT THIS TIME an additional member for the security sig WOULD be ideal.